### PR TITLE
[codex] Rename package with capacitor prefix

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [[ ! -d android ]]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [[ ! -d ios ]]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/ios/Sources/NativeGeocoderPlugin/NativeGeocoder.swift
+++ b/ios/Sources/NativeGeocoderPlugin/NativeGeocoder.swift
@@ -16,7 +16,7 @@ struct NativeGeocoderOptions: Decodable {
 
     typealias ReverseGeocodeCompletionHandler = ([JSObject]?, NativeGeocoderError?) -> Void
     typealias ForwardGeocodeCompletionHandler = ([JSObject]?, NativeGeocoderError?) -> Void
-    private static let MAX_RESULTS_COUNT = 5
+    private static let maxResultsCount = 5
 
     func reverseGeocode(latitude: Double, longitude: Double, call: CAPPluginCall) {
         if CLGeocoder().isGeocoding {
@@ -66,8 +66,8 @@ struct NativeGeocoderOptions: Decodable {
             let maxResultObjects = placemarks.count >= maxResults ? maxResults : placemarks.count
             var resultObj = [JSObject]()
 
-            for i in 0..<maxResultObjects {
-                let placemark = makePosition(placemarks[i])
+            for index in 0..<maxResultObjects {
+                let placemark = makePosition(placemarks[index])
                 resultObj.append(placemark)
             }
 
@@ -161,10 +161,10 @@ struct NativeGeocoderOptions: Decodable {
             let maxResultObjects = placemarks.count >= maxResults ? maxResults : placemarks.count
             var resultObj = [JSObject]()
 
-            for i in 0..<maxResultObjects {
-                if let latitude = placemarks[i].location?.coordinate.latitude,
-                   let longitude = placemarks[i].location?.coordinate.longitude {
-                    let placemark = makePosition(placemarks[i])
+            for index in 0..<maxResultObjects {
+                if let latitude = placemarks[index].location?.coordinate.latitude,
+                   let longitude = placemarks[index].location?.coordinate.longitude {
+                    let placemark = makePosition(placemarks[index])
                     resultObj.append(placemark)
                 }
             }
@@ -185,7 +185,7 @@ struct NativeGeocoderOptions: Decodable {
         geocoderOptions.useLocale = options.useLocale
         geocoderOptions.defaultLocale = options.defaultLocale
         if options.maxResults > 0 {
-            geocoderOptions.maxResults = options.maxResults > NativeGeocoder.MAX_RESULTS_COUNT ? NativeGeocoder.MAX_RESULTS_COUNT : options.maxResults
+            geocoderOptions.maxResults = options.maxResults > NativeGeocoder.maxResultsCount ? NativeGeocoder.maxResultsCount : options.maxResults
         } else {
             geocoderOptions.maxResults = 1
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@capgo/nativegeocoder",
-  "version": "8.0.30",
+  "name": "@capgo/capacitor-nativegeocoder",
+  "version": "8.0.32",
   "description": "Capacitor plugin for native forward and reverse geocoding",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -13,7 +13,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapgoNativegeocoder.podspec"
+    "CapgoCapacitorNativegeocoder.podspec"
   ],
   "author": "Martin Donadieu <martin@capgo.app>",
   "license": "MPL-2.0",
@@ -33,20 +33,20 @@
     "geocoder"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoNativegeocoder -destination generic/platform=iOS",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorNativegeocoder -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "verify:web": "bun run build",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
     "eslint": "eslint .",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api NativeGeocoderPlugin --output-readme README.md --output-json dist/docs.json",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Restore package metadata to `@capgo/capacitor-nativegeocoder` and version `8.0.32`.
- Keep the iOS SwiftPM/podspec product on `CapgoCapacitorNativegeocoder`.
- Clean up SwiftLint naming issues in the native geocoder source.

## Validation
- `bun run check:wiring`
- `bun run build`
- `bun run verify:web`
- `bun run verify:ios`
- `bun run lint`

`bun run verify:android` could not run locally because this machine has no Java runtime installed. CI should cover Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package to version 8.0.32 with new package name `@capgo/capacitor-nativegeocoder`.
  * Migrated build scripts from npm to bun for improved build performance.

* **Refactor**
  * Improved code clarity and consistency throughout the plugin codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-nativegeocoder/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->